### PR TITLE
Fixed calling sequence for defaultLocale

### DIFF
--- a/src/defaultLocale.js
+++ b/src/defaultLocale.js
@@ -6,6 +6,15 @@ export var timeParse;
 export var utcFormat;
 export var utcParse;
 
+function defaultLocale(definition) {
+  locale = formatLocale(definition);
+  timeFormat = locale.format;
+  timeParse = locale.parse;
+  utcFormat = locale.utcFormat;
+  utcParse = locale.utcParse;
+  return locale;
+}
+
 defaultLocale({
   dateTime: "%x, %X",
   date: "%-m/%-d/%Y",
@@ -17,11 +26,4 @@ defaultLocale({
   shortMonths: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 });
 
-export default function defaultLocale(definition) {
-  locale = formatLocale(definition);
-  timeFormat = locale.format;
-  timeParse = locale.parse;
-  utcFormat = locale.utcFormat;
-  utcParse = locale.utcParse;
-  return locale;
-}
+export default defaultLocale;


### PR DESCRIPTION
Moved definition of defaultLocale function above calling of function to make sure function definition is available before it is being called. This was creating issues with tools which work directly on ES2015+ (rollup in my case), and consuming src files directly.